### PR TITLE
feat: Replace export assignment with export default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,4 +11,4 @@ function isBackward (selection: Selection): boolean {
      (position === 0 && startOffset < endOffset));
 }
 
-export = isBackward;
+export default isBackward;


### PR DESCRIPTION
When I try to compile the library with Rollup, it comes out `semantic error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead`